### PR TITLE
Reworked the server settings articles for yunIO

### DIFF
--- a/content/_de/yunio/server-settings.md
+++ b/content/_de/yunio/server-settings.md
@@ -12,7 +12,7 @@ lang: de_DE
 old_url: /Xtract-Universal-DE/default.aspx?pageid=server
 ---
 
-Dieser Abschnitt enthält Informationen über die yunIO Server-Einstellungen.<br>
+Dieser Abschnitt enthält Informationen über die yunIO Server-Einstellungen.
 Öffnen Sie die Einstellungen unter dem Menüpunkt **Settings**. 
 Speichern Sie Änderungen der Einstellungen mit **[Save]**.
 
@@ -34,20 +34,20 @@ Klicken Sie auf **[Pick Certificate]** und wählen Sie ein X.509 Zertifikat aus 
 Falls das Zertifikat nicht in der Liste oder im Windows Certificate Store aufgelistet ist, installieren Sie das X.509 Zertifikat.
 
 {: .box-note }
-**Hinweis:** Je nachdem, ob yunIO auf einer lokalen Serverumgebung oder Cloudumgebung gehostet ist, unterscheidet sich das Vorgehen zur Zertifikaterstellung.<br>
+**Hinweis:** Je nachdem, ob yunIO auf einer lokalen Serverumgebung oder Cloudumgebung gehostet ist, unterscheidet sich das Vorgehen zur Zertifikaterstellung.
 Orientieren Sie sich an den verfügbaren Dokumentationen dazu im Netz oder wenden Sie sich an Ihre Netzwerk-Administratoren.
 
 #### TLS enabled
-Wenn ein Zertifikat gewählt wurde, ist die Option **TLS enabled** verfügbar.<br>
+Wenn ein Zertifikat gewählt wurde, ist die Option **TLS enabled** verfügbar.
 Über **TLS enabled** aktivieren oder deaktivieren Sie die Verwendung von Transportverschlüsselung für den Webserver.
 
-### Allowed Origins (CORS)
+### Allowed Origins ([CORS](https://developer.mozilla.org/de/docs/Web/HTTP/CORS))
 
 {: .box-warning }
 **Warnung! Cross-Origin Request Blocked** Wenn Sie auf einen CORS-Fehler stoßen, ist die URL Ihres Origins nicht authorisiert auf yunIO zuzugreifen.
 Fügen Sie die URL Ihres Origins der Liste authorisierter URL hinzu.
 
-Geben Sie URLs ein, die über Cross-Origin-Requests auf yunIO zugreifen dürfen.<br>
+Geben Sie URLs ein, die über Cross-Origin-Requests auf yunIO zugreifen dürfen.
 Beispiel: Um einem Tool wie Swagger Inspector zu ermöglichen, Dienste aus yunIO zu laden und zu testen, muss die URL `https://inspector.swagger.io` hinterlegt sein.
 
 {: .box-note }
@@ -56,30 +56,16 @@ Wenn Sie yunIO zum ersten Mal installieren, ist diese Einstellung automatisch ge
 
 ### Services
 
-Definieren Sie hier die Ports für Ihre Service-Aufrufe.
+Definieren Sie hier die Ports für Ihre Service-Aufrufe. Erlaubt sind Ports im Bereich 1-65535. Es ist nicht empfohlen Ports unter 1000 zu verwenden, da diese meist bereits von anderen Diensten besetzt sind und die doppelte Nutzung eines Ports zu Ausfällen und Fehlern führt.
 
-#### HTTP port
-Dieser Port wird für Service-Aufrufe verwendet, wenn kein TLS aktiv ist. Der Standard-Port lautet **8075**. Die maximale Portnummer ist 65535.
+### Services
 
-#### HTTPS port
-Dieser Port wird für Service-Aufrufe verwendet, wenn TLS aktiviert ist. Der Standard-Port lautet **8175**.Die maximale Portnummer ist 65535.
+Define the ports for service consumption here. Valid port numbers range from 1-65535. Although it is not recommended to use ports below 1000 since they often are already taken and using them with different services leads to service disruptions and errors.
 
-### Designer
+#### Default Ports
 
-Definieren Sie hier die Ports für den yunIO Designer.
-
-#### HTTP port
-Dieser Port wird verwendet, um auf den Designer zuzugreifen, wenn kein TLS aktiv ist. Der Standard-Port lautet **8077**. Die maximale Portnummer ist 65535.
-
-#### HTTPS port
-Dieser Port wird verwendet, um auf den Designer zuzugreifen, wenn TLS aktiviert ist. Der Standard-Port lautet **8177**. Die maximale Portnummer ist 65535.
-
-### WebSockets
-
-Definieren Sie die Ports für die Kommunikation zwischen dem Designer und dem yunIO-Server.
-
-#### HTTP port
-Dieser Port wird für die Kommunikation zwischen dem Designer und dem yunIO-Server, wenn keine TLS aktiv ist. Der Standard-Port lautet **8078**. Die maximale Portnummer ist 65535.
-
-#### HTTPS port
-Dieser Port wird für die Kommunikation zwischen dem Designer und dem yunIO-Server, wenn TLS aktiviert ist. Der Standard-Port lautet **8178**. Die maximale Portnummer ist 65535.
+|Service Name|Http|Https|Description|
+|---|---|---|---|
+|WebServer|8075|8175|Dieser Port wird vom Webserver verwendet der die Anfragen annimmt, um Services zu starten.|
+|WebSockets|8076|8176|Dieser Port wird vom yunIO Designer verwendet, um Konfigurationen, Services und dergleichen anzupassen.|
+|Designer|8077|8177|Dieser Port wird genutzt, um den yunIO Designer aufzurufen.|

--- a/content/_de/yunio/server-settings.md
+++ b/content/_de/yunio/server-settings.md
@@ -24,10 +24,9 @@ Speichern Sie Änderungen der Einstellungen mit **[Save]**.
 ### Transport Layer Security
 
 Das *Transport Layer Security (TLS)*-Protokoll ermöglicht eine verschlüsselte Datenübertragung.
-Wenn TLS aktiviert ist, wird auf den Webserver über eine https-Verbindung zugegriffen.
-Dafür muss ein X.509 Zertifikat installiert sein. 
+Wenn TLS aktiviert ist, wird auf den jeweiligen Dienst über eine HTTPS-Verbindung zugegriffen.
+Dafür muss ein X.509 Zertifikat installiert sein.
 Für mehr Informationen zu TLS, siehe [Microsoft: TLS-Protokoll](https://docs.microsoft.com/de-de/windows/win32/secauthn/transport-layer-security-protocol).
-
 
 #### Pick Certificate
 Klicken Sie auf **[Pick Certificate]** und wählen Sie ein X.509 Zertifikat aus der Liste verfügbarer Zertifikate aus.

--- a/content/_en/yunio/server-settings.md
+++ b/content/_en/yunio/server-settings.md
@@ -13,7 +13,7 @@ old_url: /Xtract-Universal-DE/default.aspx?pageid=server
 ---
  
 
-The follwing section contains an overview of the yunIO server settings in the **Settings** menu. <br>
+The following section contains an overview of the yunIO server settings in the **Settings** menu.
 To save any changes made in the **Settings** menu, click **[Save]**.
 
 {: .box-note }
@@ -21,15 +21,14 @@ To save any changes made in the **Settings** menu, click **[Save]**.
 
 ![Server-Settings](/img/content/yunio/Server-settings.png){:class="img-responsive" }
 
-
 ### Transport Layer Security
 
-Transport Layer Security (TLS) protocol encrypts data that is processed with yunIO.
-When TLS is enabled, access restrictions require accessing the web server through an HTTPS connection. This requires the installation of an X.509 certificate.
+Transport Layer Security (TLS) protocol allows the user to communicate with the respective service in a secure way by encrypting the communication with that service (HTTPS).
+This requires the installation of an X.509 certificate.
 For more information on TLS, see [Microsoft: Transport Layer Security Protocol](https://docs.microsoft.com/en-us/windows/win32/secauthn/transport-layer-security-protocol).
 
 #### Pick Certificate
-Click **[Pick Certificate]** and select an X.509 certificate from the list of available certificates.<br>
+Click **[Pick Certificate]** and select an X.509 certificate from the list of available certificates.
 If the certificate is not listed in the menu or in the Windows certificate store, install the X.509 certificate.
 
 {: .box-note }
@@ -37,15 +36,15 @@ If the certificate is not listed in the menu or in the Windows certificate store
 Please refer to the documentation available on the internet or contact your network administrators.
 
 #### TLS enabled
-Once a certificate is selected, the option **TLS enabled** is available.<br>
+Once a certificate is selected, the option **TLS enabled** is available.
 Enable or disable the usage of transport encryption for the web server.
 
-### Allowed Origins (CORS)
+### Allowed Origins ([CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS))
 
 {: .box-warning }
 **Warning! Cross-Origin Request Blocked** When encountering a CORS error, the URL of your origin is not authorized to send requests to yunIO. Add the URL of your origin to the list of allowed origins.
 
-Enter URLs that are allowed to run cross-origin requests on yunIO.<br>
+Enter URLs that are allowed to run cross-origin requests on yunIO.
 Example: To allow a tool like Swagger Inspector to load and execute a yunIO service, the URL `https://inspector.swagger.io` must be added to the list of allowed origins.
 
 {: .box-note }
@@ -54,32 +53,12 @@ Example: To allow a tool like Swagger Inspector to load and execute a yunIO serv
 
 ### Services
 
-Define the ports for service consumption here. 
+Define the ports for service consumption here. Valid port numbers range from 1-65535. Although it is not recommended to use ports below 1000 since they often are already taken and using them with different services can lead to service disruptions.
 
-#### HTTP port
-This port is used for service consumption if TLS is disabled. Default port is **8075**. The maximum port number is 65535.
+#### Default Ports
 
-#### HTTPS port
-This port is used for service consumption if TLS is enabled. Default port is **8175**. The maximum port number is 65535.
-
-
-### Designer
-
-Define the ports of the yunIO Designer. 
-
-#### HTTP port
-This port is used to access the yunIO Designer if TLS is disabled. Default port is **8077**. The maximum port number is 65535.
-
-#### HTTPS port
-This port is used to access the yunIO Designer if TLS is enabled. Default port is **8177**. The maximum port number is 65535.
-
-
-### WebSockets
-
-Define the ports for the communication between the yunIO Designer and the yunIO server. 
-
-#### HTTP port
-This port is used for the communication between the yunIO Designer and the yunIO server if TLS is disabled. Default port is **8078**. The maximum port number is 65535.
-
-#### HTTPS port
-This port is used for the communication between the yunIO Designer and the yunIO server if TLS is enabled. Default port is **8178**.The maximum port number is 65535.
+|Service Name|Http|Https|Description|
+|---|---|---|---|
+|WebServer|8075|8175|This port is used by the web server which takes the requests to invoke a service.|
+|WebSockets|8076|8176|This port is used by the yunIO Designer to read and write configurations, services and the like|
+|Designer|8077|8177|This port is used to serve the yunIO Designer to a client machine.|

--- a/content/_en/yunio/server-settings.md
+++ b/content/_en/yunio/server-settings.md
@@ -61,4 +61,4 @@ Define the ports for service consumption here. Valid port numbers range from 1-6
 |---|---|---|---|
 |WebServer|8075|8175|This port is used by the web server which takes the requests to invoke a service.|
 |WebSockets|8076|8176|This port is used by the yunIO Designer to read and write configurations, services and the like|
-|Designer|8077|8177|This port is used to serve the yunIO Designer to a client machine.|
+|Designer|8077|8177|This port is used to open the yunIO Designer on a client machine.|


### PR DESCRIPTION
I rewrote the TLS section to be more clear and technically correct.
The overview for the ports is now a simple table.
I think the \<br> tags were useless, so I removed them as well.